### PR TITLE
Fix bootstrap.sh URL

### DIFF
--- a/wiki/PatatrackReleases.md
+++ b/wiki/PatatrackReleases.md
@@ -25,7 +25,7 @@ cd <...>
 export VO_CMS_SW_DIR=$PWD
 export SCRAM_ARCH=slc7_amd64_gcc700
 export LANG=C
-wget http://cmsrep.cern.ch/cmssw/repos/bootstrap.sh -O $VO_CMS_SW_DIR/bootstrap.sh
+wget http://cmsrep.cern.ch/cmssw/bootstrap.sh -O $VO_CMS_SW_DIR/bootstrap.sh
 chmod a+x $VO_CMS_SW_DIR/bootstrap.sh
 $VO_CMS_SW_DIR/bootstrap.sh -a slc7_amd64_gcc700 -r cms -path $VO_CMS_SW_DIR setup
 ```


### PR DESCRIPTION
Noticed this from
https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/2606/1/1/2.html
With the proposed one I am able to install CMSSW e.g. on LPC (that was previously failing with libGL.so).

@fwyzard What do you think?