### PR TITLE
Fixed cuda2alpaka rules appearance

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
         - Alpaka and Cupla: AlpakaAndCupla.md
         - CUDA to cupla: cuda2cupla.md
         - CUDA to Alpaka: cuda2alpaka.md
+        - CUDA to Alpaka rules: cuda2alpaka_rules.md
         - CUDA to HIP: CUDAtoHIP.md
         - SYCL LLVM compiler: SYCL.md
         - CUDA to cupla: cuda2cupla.md 


### PR DESCRIPTION
Cuda to alpaka rules were not appearing in the navigation menu.